### PR TITLE
Google商標に関するテキスト修正

### DIFF
--- a/html/5mingcp/index.html
+++ b/html/5mingcp/index.html
@@ -42,7 +42,7 @@
 <div class="jumbotron-fluid mb-0">
     <div class="container d-flex align-items-center">
         <div id="mainv">
-            <h1 class="mb-0"><span>5分から</span>相談<br>できる<br>GCP&trade; 開発<br>コンサル！</h1>
+            <h1 class="mb-0"><span>5分から</span>相談<br>できる<br>GCP&trade;&nbsp;開発<br>コンサル！</h1>
             <a href="https://docs.google.com/forms/d/e/1FAIpQLSf_BvWBGzazz5imaARqB2q_K3BQA7MXfaSNIRzns5yEJ9SzzQ/viewform?usp=sf_link" class="btn btn-outline-warning btn-lg text-white rounded-0" target="_blank">お問い合わせ</a>
         </div>
     </div>
@@ -55,7 +55,7 @@
         <ul class="secul">
           <li>GCP のサービスが多くて何をつかったらよいかわからない</li>
           <li>GCP ランニングコストを出来るだけ抑えたい</li>
-          <li>Cloud Datastore /Cloud Firestore&trade; の設計方法がわからない</li>
+          <li>Cloud Firestore&trade;&nbsp;の設計方法がわからない</li>
           <li>難しそうなところだけ開発を手伝って欲しい</li>
         </ul>
 
@@ -89,7 +89,7 @@
 
       <h2>対応サービス＆技術</h2>
       <ul class="secul">
-        <li>Google App Engine&trade; (GAE)
+        <li>Google App Engine&trade;&nbsp;(GAE)
           <span>
               <i class="fas fa-star"></i>
               <i class="fas fa-star"></i>
@@ -99,7 +99,7 @@
           </span>
         </li>
         
-        <li>Google Kubernetes Engine (GKE)
+        <li>Google Kubernetes Engine&trade;&nbsp;(GKE)
           <span>
               <i class="fas fa-star"></i>
               <i class="fas fa-star"></i>
@@ -107,16 +107,7 @@
           </span>
         </li>
         
-        <li>Firebase&trade; 
-          <span>
-              <i class="fas fa-star"></i>
-              <i class="fas fa-star"></i>
-              <i class="fas fa-star"></i>
-              <i class="fas fa-star"></i>
-          </span>
-        </li>
-        
-        <li>Google Compute Engine&trade; (GCE)
+        <li>Firebase&trade;&nbsp;
           <span>
               <i class="fas fa-star"></i>
               <i class="fas fa-star"></i>
@@ -125,9 +116,8 @@
           </span>
         </li>
         
-        <li>Cloud Datastore 
+        <li>Google Compute Engine&trade;&nbsp;(GCE)
           <span>
-              <i class="fas fa-star"></i>
               <i class="fas fa-star"></i>
               <i class="fas fa-star"></i>
               <i class="fas fa-star"></i>
@@ -135,7 +125,7 @@
           </span>
         </li>
         
-        <li>Cloud Firestore&trade; (Datastore mode)
+        <li>Cloud Firestore&trade;&nbsp;(Datastore mode)
           <span>
               <i class="fas fa-star"></i>
               <i class="fas fa-star"></i>
@@ -145,7 +135,7 @@
           </span>
         </li>
         
-        <li>Cloud Firestore&trade; (Native mode)
+        <li>Cloud Firestore&trade;&nbsp;(Native mode)
           <span>
               <i class="fas fa-star"></i>
               <i class="fas fa-star"></i>
@@ -241,7 +231,7 @@
 
 <footer id="footer">
   <div class="container">
-  <p>※「GCP」、「Google Cloud Platform」、「Cloud Firestore」、「Google App Engine」、「Firebase」 および 「Google Compute Engine」は、Google LCC の商標または登録商標です<br>
+  <p>※「GCP」、「Google Cloud Platform」、「Cloud Firestore」、「Google App Engine」、「Google Kubernetes Engine」、「Firebase」 および 「Google Compute Engine」は、Google LCC の商標または登録商標です<br>
 ※ 記載されている会社名、サービス名、商品名は、各社の商標または登録商標です</p></div>
     
     <div id="copyright">

--- a/html/5mingcp/index.html
+++ b/html/5mingcp/index.html
@@ -42,7 +42,7 @@
 <div class="jumbotron-fluid mb-0">
     <div class="container d-flex align-items-center">
         <div id="mainv">
-            <h1 class="mb-0"><span>5分から</span>相談<br>できる<br>GCP開発<br>コンサル！</h1>
+            <h1 class="mb-0"><span>5分から</span>相談<br>できる<br>GCP&trade; 開発<br>コンサル！</h1>
             <a href="https://docs.google.com/forms/d/e/1FAIpQLSf_BvWBGzazz5imaARqB2q_K3BQA7MXfaSNIRzns5yEJ9SzzQ/viewform?usp=sf_link" class="btn btn-outline-warning btn-lg text-white rounded-0" target="_blank">お問い合わせ</a>
         </div>
     </div>
@@ -51,11 +51,11 @@
 <section id="sec1">
     <div class="container">
 
-        <h2>GCPを用いた開発でお困りの方</h2>
+        <h2>GCP を用いた開発でお困りの方</h2>
         <ul class="secul">
-          <li>GCPのサービスが多くて何をつかったらよいかわからない</li>
-          <li>GCPランニングコストを出来るだけ抑えたい</li>
-          <li>Datastore/Firestoreの設計方法がわからない</li>
+          <li>GCP のサービスが多くて何をつかったらよいかわからない</li>
+          <li>GCP ランニングコストを出来るだけ抑えたい</li>
+          <li>Cloud Datastore /Cloud Firestore&trade; の設計方法がわからない</li>
           <li>難しそうなところだけ開発を手伝って欲しい</li>
         </ul>
 
@@ -89,7 +89,7 @@
 
       <h2>対応サービス＆技術</h2>
       <ul class="secul">
-        <li>Google App Engine(GAE)
+        <li>Google App Engine&trade; (GAE)
           <span>
               <i class="fas fa-star"></i>
               <i class="fas fa-star"></i>
@@ -99,7 +99,7 @@
           </span>
         </li>
         
-        <li>Google Kubernetes Engine(GKE)
+        <li>Google Kubernetes Engine (GKE)
           <span>
               <i class="fas fa-star"></i>
               <i class="fas fa-star"></i>
@@ -107,16 +107,7 @@
           </span>
         </li>
         
-        <li>Firebase
-          <span>
-              <i class="fas fa-star"></i>
-              <i class="fas fa-star"></i>
-              <i class="fas fa-star"></i>
-              <i class="fas fa-star"></i>
-          </span>
-        </li>
-        
-        <li>Google Compute Engine(GCE)
+        <li>Firebase&trade; 
           <span>
               <i class="fas fa-star"></i>
               <i class="fas fa-star"></i>
@@ -125,9 +116,8 @@
           </span>
         </li>
         
-        <li>Cloud Datastore
+        <li>Google Compute Engine&trade; (GCE)
           <span>
-              <i class="fas fa-star"></i>
               <i class="fas fa-star"></i>
               <i class="fas fa-star"></i>
               <i class="fas fa-star"></i>
@@ -135,7 +125,7 @@
           </span>
         </li>
         
-        <li>Cloud Firestore(Datastore mode)
+        <li>Cloud Datastore 
           <span>
               <i class="fas fa-star"></i>
               <i class="fas fa-star"></i>
@@ -145,7 +135,17 @@
           </span>
         </li>
         
-        <li>Cloud Firestore(Native mode)
+        <li>Cloud Firestore&trade; (Datastore mode)
+          <span>
+              <i class="fas fa-star"></i>
+              <i class="fas fa-star"></i>
+              <i class="fas fa-star"></i>
+              <i class="fas fa-star"></i>
+              <i class="fas fa-star"></i>
+          </span>
+        </li>
+        
+        <li>Cloud Firestore&trade; (Native mode)
           <span>
               <i class="fas fa-star"></i>
               <i class="fas fa-star"></i>
@@ -154,7 +154,7 @@
           </span>
         </li>
         
-        <li>Cloud SQL
+        <li>Cloud SQL 
           <span>
               <i class="fas fa-star"></i>
               <i class="fas fa-star"></i>
@@ -241,7 +241,7 @@
 
 <footer id="footer">
   <div class="container">
-  <p>※「 Google Cloud Platform (GCP) 」は、 Google LLC　の商標または登録商標です<br>
+  <p>※「GCP」、「Google Cloud Platform」、「Cloud Firestore」、「Google App Engine」、「Firebase」 および 「Google Compute Engine」は、Google LCC の商標または登録商標です<br>
 ※ 記載されている会社名、サービス名、商品名は、各社の商標または登録商標です</p></div>
     
     <div id="copyright">


### PR DESCRIPTION
**フィードバック内容**
```
下記の通り、弊社ガイドライン上の半角スペースと商標に関する規定をご確認いただき、反映していただけますと幸いです。
こちら(https://www.google.com/permissions/trademark/trademark-list/)の商標一覧をご確認いただき、商標の初出時に「TM」の付記をお願いいたします。（例：Google™)
製品名の日本語表記に関しては、各製品の公式ページをご参照ください。（例：Google ドライブ、は Google の後ろに半角スペースが入り後半はカタカナ）
全体的に、弊社ローマ字名称の前後には半角スペースの挿入をお願いいたします。
資料末尾に該当する商標に関する文章の記載をお願いいたします：Google、Google Cloud、●●、▲▲、および、XX は、Google LCC の商標です。
```

**↑対して池田からの質問**
```
現在末尾に下記２文記しています。
※「 Google Cloud Platform (GCP) 」は、 Google LLC　の商標または登録商標です
※ 記載されている会社名、サービス名、商品名は、各社の商標または登録商標です

後ろの文では不十分で、詳細なサービス(Google App Engine, Google Compute Engine, etc)全て明記する必要がある、という
指摘でよろしいでしょうか。
```

**↑に対する回答**
```
商標につきましては、全ての商標の初出時にに「TM」を付記していただき（2 回目以降は省略可能です）、
末尾に、該当する商標を全て書き出していただきたく、お願いいたします。
その際、Google Cloud Platform と GCP はそれぞれが商標となりますので分けて記載をお願いいたします。

また、商標一覧のページは英語版しかなく、日本語の表記につきましては
各製品の公式サイトやこちら(https://about.google/intl/ja/products/)にて日本語の表記をご確認ください。
```