### PR TITLE
Java商標に関するテキスト修正

### DIFF
--- a/html/5mingcp/index.html
+++ b/html/5mingcp/index.html
@@ -170,7 +170,7 @@
           </span>
         </li>
         
-        <li>Java
+        <li>Java&trade;
           <span>
               <i class="fas fa-star"></i>
               <i class="fas fa-star"></i>
@@ -239,8 +239,9 @@
 
 <footer id="footer">
   <div class="container">
-  <p>※GCP、Google Cloud Platform、Cloud Firestore、Google App Engine、GKE、Firebase、Google Compute Engine および BigQueryは、Google LCC の商標です<br>
-※ 記載されている会社名、サービス名、商品名は、各社の商標です</p></div>
+  <p>※ GCP、Google Cloud Platform、Cloud Firestore、Google App Engine、GKE、Firebase、Google Compute Engine および BigQueryは、Google LCC の商標です。<br>
+※ OracleおよびJavaは、オラクルおよびその関連会社の登録商標です。その他の社名、商品名等は各社の商標または登録商標である場合があります。<br>
+※ 記載されている会社名、サービス名、商品名は、各社の商標です。</p></div>
     
     <div id="copyright">
         <p class="text-center mb-0 pt-3 pb-3">&copy;&ensp;Knightso LLC. All Rights Reserved.</p>

--- a/html/5mingcp/index.html
+++ b/html/5mingcp/index.html
@@ -240,8 +240,8 @@
 <footer id="footer">
   <div class="container">
   <p>※ GCP、Google Cloud Platform、Cloud Firestore、Google App Engine、GKE、Firebase、Google Compute Engine および BigQueryは、Google LCC の商標です。<br>
-※ OracleおよびJavaは、オラクルおよびその関連会社の登録商標です。その他の社名、商品名等は各社の商標または登録商標である場合があります。<br>
-※ 記載されている会社名、サービス名、商品名は、各社の商標です。</p></div>
+※ OracleおよびJavaは、オラクルおよびその関連会社の登録商標です。<br>
+※ その他の社名、商品名等は各社の商標または登録商標である場合があります。</p></div>
     
     <div id="copyright">
         <p class="text-center mb-0 pt-3 pb-3">&copy;&ensp;Knightso LLC. All Rights Reserved.</p>


### PR DESCRIPTION
「Java」の商標について下記サイトを参考に記述を追加しました。

■第三者によるオラクル商標の使用ガイドライン
https://www.oracle.com/jp/legal/trademarks.html